### PR TITLE
Fix a series of editing bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,11 +103,13 @@ dependencies = [
 name = "cred"
 version = "0.4.0"
 dependencies = [
+ "chrono",
  "clipboard",
  "env_logger",
  "lazy_static",
  "log",
  "log4rs",
+ "rand 0.7.3",
  "regex",
  "rustbox",
  "termbox-sys",
@@ -169,6 +171,17 @@ checksum = "8cc0b9f53275dc5fada808f1d2f82e3688a6c14d735633d1590b7be8eb2307b5"
 dependencies = [
  "libc",
  "tempfile",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -403,6 +416,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +469,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom",
+ "libc",
+ "rand_chacha",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +505,24 @@ name = "rand_core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
 
 [[package]]
 name = "rdrand"
@@ -683,7 +743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -732,6 +792,12 @@ dependencies = [
  "rand 0.3.23",
  "serde",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.11"
+chrono = "0.4"
+rand = "0.7.3" 
 regex = "1.3.9"
 lazy_static = "1.0.1"
 env_logger = "0.7.1"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ Github actions also trigger on each push. See .github/workflows/runtest.yml for 
 Current priority is a focus on making editor more resilient, finding bugs and the ability to better edit itself.
 
 Assorted ideas for future releases:
-* show line numbers
 * allow shortcut configuration
 * handle large files gracefully (async load, optimize simple commands)
 * compile rust source file (Rust)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@ A Linux WYSIWYG console editor in Rust(!) loosely inspired by ye-olde Turbo Pasc
 This editor makes most commands available to left hand only since right hand is way overused in development 
 and avoids piano 2+ keys shortcuts.
 
+
+## Prerequisites
+
+On Debian 11 make sure to install libxcb libraries:
+```bash
+sudo apt install libxcb-xfixes0-dev
+```
+
+## Build and run
+
+To build
+```bash
+cargo build
+```
+
 To run
 ```bash
 cargo r

--- a/check.sh
+++ b/check.sh
@@ -8,7 +8,6 @@ then
 else
 	echo "Formatting check failed"
 	echo "To fix formatting run #cargo fmt --all"
-	exit(1)
 fi
 
 cargo clippy -- -Dwarnings
@@ -17,5 +16,4 @@ then
 	echo "Clippy check succeeded."
 else
 	echo "Clippy check failed"
-	exit(1)
 fi

--- a/src/cred/common.rs
+++ b/src/cred/common.rs
@@ -32,7 +32,7 @@ use std::slice::Iter;
  * Each element of that heap has a reference to a control.
  * Each control is stored in a separate field
  */
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ControlType {
     FileBuffer,
     Menu,
@@ -141,7 +141,7 @@ pub const NUMBER: FontStyle = FontStyle {
 };
 */
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Coverage {
     // select from start to end
     FromTo,
@@ -156,7 +156,7 @@ impl Coverage {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum UndoRedoAction {
     Undo,
     Redo,

--- a/src/cred/controls.rs
+++ b/src/cred/controls.rs
@@ -3166,7 +3166,7 @@ impl OpenFileMenu {
         for entry in fs::read_dir(dir.as_path())? {
             match entry {
                 Ok(dir) => {
-                    dirs_to_process.push(PathBufItem{
+                    dirs_to_process.push(PathBufItem {
                         depth: 0,
                         pathbuf: dir.path().to_path_buf(),
                     });
@@ -3179,7 +3179,11 @@ impl OpenFileMenu {
 
         dirs_to_process.sort_by(|l, r| {
             if l.pathbuf.is_dir() == r.pathbuf.is_dir() {
-                l.pathbuf.to_str().unwrap().partial_cmp(&r.pathbuf.to_str().unwrap()).unwrap()
+                l.pathbuf
+                    .to_str()
+                    .unwrap()
+                    .partial_cmp(&r.pathbuf.to_str().unwrap())
+                    .unwrap()
             } else if l.pathbuf.is_dir() && !r.pathbuf.is_dir() {
                 Ordering::Less
             } else {
@@ -3196,7 +3200,8 @@ impl OpenFileMenu {
             let is_dir = pathbuf_item.pathbuf.is_dir();
             if !self.pattern.is_empty()
                 && !is_dir
-                && !String::from(pathbuf_item.pathbuf.to_str().unwrap_or("")).contains(&self.pattern)
+                && !String::from(pathbuf_item.pathbuf.to_str().unwrap_or(""))
+                    .contains(&self.pattern)
             {
                 continue;
             }
@@ -3222,11 +3227,10 @@ impl OpenFileMenu {
                 for entry in fs::read_dir(pathbuf_item.pathbuf.as_path())? {
                     match entry {
                         Ok(dir) => {
-                            subdirs_to_process
-                                .push(PathBufItem{
-                                    depth: pathbuf_item.depth + 1,
-                                    pathbuf: dir.path().to_path_buf(),
-                                });
+                            subdirs_to_process.push(PathBufItem {
+                                depth: pathbuf_item.depth + 1,
+                                pathbuf: dir.path().to_path_buf(),
+                            });
                         }
                         Err(e) => {
                             log::warn!("Failed reading dir: {:?} reason: {:?}", dir, e);
@@ -3236,7 +3240,11 @@ impl OpenFileMenu {
 
                 subdirs_to_process.sort_by(|l, r| {
                     if l.pathbuf.is_dir() == r.pathbuf.is_dir() {
-                        l.pathbuf.to_str().unwrap().partial_cmp(&r.pathbuf.to_str().unwrap()).unwrap()
+                        l.pathbuf
+                            .to_str()
+                            .unwrap()
+                            .partial_cmp(&r.pathbuf.to_str().unwrap())
+                            .unwrap()
                     } else if l.pathbuf.is_dir() && !r.pathbuf.is_dir() {
                         Ordering::Less
                     } else {

--- a/src/cred/controls.rs
+++ b/src/cred/controls.rs
@@ -3159,7 +3159,6 @@ impl OpenFileMenu {
      * Load first N-levels directory and files under given path
      */
     fn load_directory(&self, dir: PathBuf, levels: usize) -> std::io::Result<Vec<FileItem>> {
-        log::info!("Running load directory");
         let mut children: Vec<FileItem> = Vec::new();
 
         let mut dirs_to_process: Vec<PathBufItem> = Vec::new();
@@ -3173,7 +3172,7 @@ impl OpenFileMenu {
                     });
                 }
                 Err(e) => {
-                    log::warn!("Failed readir dir: {:?} reason: {:?}", dir, e);
+                    log::warn!("Failed reading dir: {:?} reason: {:?}", dir, e);
                 }
             }
         }
@@ -3389,7 +3388,6 @@ impl OpenFileMenu {
                 if String::from(current_item.path.as_path().to_str().unwrap_or(""))
                     .starts_with(&item_path)
                 {
-                    log::warn!("Selecting item: {:?} {:?}", current_item, item_path);
                     current_item.visible = item.expanded;
                 }
             }

--- a/src/cred/controls.rs
+++ b/src/cred/controls.rs
@@ -101,7 +101,7 @@ const CTRL_UNDO_REDO_SHORTCUT: char = 'z';
 // search shortcuts
 const CTRL_SEARCH_SHORTCUT: char = 'f';
 const SEARCH_FORWARD_SHORTCUT: char = 'f';
-const SEARCH_BACKWARD_SHORTCUT: char = 'd';
+const SEARCH_BACKWARD_SHORTCUT: char = 'b';
 
 // wsad movement shortcuts where applicable
 const GAME_UP_SHORTCUT: char = 'w';

--- a/src/cred/controls.rs
+++ b/src/cred/controls.rs
@@ -3182,7 +3182,7 @@ impl OpenFileMenu {
                 l.pathbuf
                     .to_str()
                     .unwrap()
-                    .partial_cmp(&r.pathbuf.to_str().unwrap())
+                    .partial_cmp(r.pathbuf.to_str().unwrap())
                     .unwrap()
             } else if l.pathbuf.is_dir() && !r.pathbuf.is_dir() {
                 Ordering::Less
@@ -3214,7 +3214,7 @@ impl OpenFileMenu {
                     pathbuf_item.depth == 0
                 };
                 children.push(FileItem {
-                    is_dir: is_dir,
+                    is_dir,
                     path: pathbuf_item.pathbuf.clone(),
                     expanded: false,
                     depth: pathbuf_item.depth,
@@ -3243,7 +3243,7 @@ impl OpenFileMenu {
                         l.pathbuf
                             .to_str()
                             .unwrap()
-                            .partial_cmp(&r.pathbuf.to_str().unwrap())
+                            .partial_cmp(r.pathbuf.to_str().unwrap())
                             .unwrap()
                     } else if l.pathbuf.is_dir() && !r.pathbuf.is_dir() {
                         Ordering::Less
@@ -3252,10 +3252,8 @@ impl OpenFileMenu {
                     }
                 });
 
-                let mut entry_index = 0;
-                for subdir in subdirs_to_process {
+                for (entry_index, subdir) in subdirs_to_process.into_iter().enumerate() {
                     dirs_to_process.insert(entry_index, subdir);
-                    entry_index += 1;
                 }
             }
         }

--- a/src/cred/controls.rs
+++ b/src/cred/controls.rs
@@ -1129,8 +1129,10 @@ impl FileBuffer {
                     }
                 }
                 Key::Delete => {
-                    let content = self.contents[self.text_location].to_string();
-                    self.action_do(Action::remove(self.text_location, content, 1));
+                    if self.text_location < (self.contents.len() - 1) {
+                        let content = self.contents[self.text_location].to_string();
+                        self.action_do(Action::remove(self.text_location, content, 1));
+                    }
                 }
                 Key::Insert => {
                     // TODO: implement insert semantics

--- a/src/cred/controls.rs
+++ b/src/cred/controls.rs
@@ -3374,7 +3374,10 @@ impl OpenFileMenu {
         if selected_path.is_none() {
             let item = self.items[self.selected_index].clone();
 
-            let item_path = String::from(item.path.as_path().to_str().unwrap_or(""));
+            let mut item_path = String::from(item.path.as_path().to_str().unwrap_or(""));
+            // appending platform file separator solves the issue with expanding same-prefixed
+            // folders (ie. .git, .github)
+            item_path.push(std::path::MAIN_SEPARATOR);
             for current_item in self.items.iter_mut() {
                 if current_item.path == item.path {
                     continue;
@@ -3386,6 +3389,7 @@ impl OpenFileMenu {
                 if String::from(current_item.path.as_path().to_str().unwrap_or(""))
                     .starts_with(&item_path)
                 {
+                    log::warn!("Selecting item: {:?} {:?}", current_item, item_path);
                     current_item.visible = item.expanded;
                 }
             }

--- a/src/cred/events.rs
+++ b/src/cred/events.rs
@@ -37,7 +37,7 @@ pub enum WindowAction {
     Close,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DialogType {
     Save,
     Goto,
@@ -88,7 +88,7 @@ pub struct UndoEvent {
 #[derive(Clone, Debug)]
 pub struct ExitEvent {}
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SearchDirection {
     Forward,
     Backward,
@@ -100,7 +100,7 @@ pub struct SearchEvent {
     pub pattern: String,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum SelectAction {
     // user selected start of selection
     Start,

--- a/src/cred/tests.rs
+++ b/src/cred/tests.rs
@@ -306,7 +306,7 @@ mod tests {
 
         let contents: Vec<char> = String::from("test").chars().map(|x| x as char).collect();
         file_buffer.to_clipboard(contents);
-        file_buffer.from_clipboard();
+        file_buffer.copy_clipboard();
 
         let slice = file_buffer.get_slice_string(0, 5);
         assert_eq!("test", slice);

--- a/src/cred/tests.rs
+++ b/src/cred/tests.rs
@@ -25,6 +25,11 @@
 #[cfg(test)]
 mod tests {
 
+    use chrono::Utc;
+    use std::fs;
+    use std::env;
+    use std::fs::File;
+    use std::io::Write;
     use std::path::PathBuf;
     use std::sync::Once;
 
@@ -40,6 +45,7 @@ mod tests {
     use std::error::Error;
 
     use crate::cred::events::HandleSearchEvent;
+    use rand::Rng;
     use rustbox::{Event, ExtendedKey, Key, Modifiers, OutputMode};
 
     static LOG_INIT: Once = Once::new();
@@ -292,6 +298,7 @@ mod tests {
         assert_eq!(false, editor.handle_event_option(Some(Ok(exit_shortcut))));
     }
 
+    // TODO: Fix
     #[ignore]
     #[test]
     fn test_editor_copy_paste() {
@@ -473,5 +480,72 @@ mod tests {
             let text_location = file_buffer.get_text_location();
             assert_eq!(0, text_location);
         }
+    }
+
+    #[test]
+    fn test_editor_save() {
+        assert_eq!(true, setup().is_ok());
+        let mut editor = Editor::new();
+        assert_eq!(true, editor.init(OutputMode::NoOutput).is_ok());
+
+        let hide_help =
+            Event::KeyEvent(ExtendedKey::new(Key::Esc, Modifiers { ..Modifiers::new() }));
+        assert_eq!(true, editor.handle_event_option(Some(Ok(hide_help))));
+
+        let temp_file = gen_testfile(String::from("test"));
+
+        let open_this_test = events::Event {
+            open_file_event: Some(events::OpenFileEvent {
+                path: PathBuf::from(temp_file.clone()),
+            }),
+            ..events::Event::new()
+        };
+        assert_eq!(true, editor.handle_event(open_this_test));
+        assert_eq!(2, editor.file_buffer_controls.len());
+
+        let file_buffer = editor.get_active_file_buffer().unwrap();
+        let slice = file_buffer.get_slice_string(0, 18);
+        assert_eq!("test", slice);
+
+        let key_newline = Event::KeyEvent(ExtendedKey::new(Key::Char('1'), Modifiers::new()));
+        assert_eq!(true, editor.handle_event_option(Some(Ok(key_newline))));
+        let ok = Event::KeyEvent(ExtendedKey::new(Key::Enter, Modifiers::new()));
+        assert_eq!(true, editor.handle_event_option(Some(Ok(ok))));
+
+        let menu = Event::KeyEvent(ExtendedKey::new(
+            Key::Char('d'),
+            Modifiers {
+                ctrl: true,
+                ..Modifiers::new()
+            },
+        ));
+        assert_eq!(true, editor.handle_event_option(Some(Ok(menu))));
+
+        let save_shortcut = Event::KeyEvent(ExtendedKey::new(Key::Char('s'), Modifiers::new()));
+        assert_eq!(true, editor.handle_event_option(Some(Ok(save_shortcut))));
+
+        let save_ok = Event::KeyEvent(ExtendedKey::new(Key::Enter, Modifiers::new()));
+        assert_eq!(true, editor.handle_event_option(Some(Ok(save_ok))));
+
+        let saved_contents = fs::read_to_string(temp_file.clone()).unwrap();
+        assert_eq!("1\ntest", saved_contents)
+    }
+
+    // ideally files shouldn't be created on disk for unit tests but this is convenient for the
+    // moment
+    fn gen_testfile(contents: String) -> String {
+        let dir = env::temp_dir();
+        let mut rng = rand::thread_rng();
+        let num: u64 = rng.gen();
+        let dt = Utc::now();
+        let timestamp: i64 = dt.timestamp();
+        let temp_file = dir.join(format!("cred-test-file-{}-{}", timestamp, num));
+        let mut file = File::create(temp_file.clone()).unwrap();
+        file.write(contents.as_bytes()).unwrap();
+        let temp_filename = &temp_file.into_os_string().into_string();
+        return match temp_filename {
+            Ok(v) => v.clone(),
+            Err(_) => String::new(),
+        };
     }
 }


### PR DESCRIPTION
Fixes the following issues:
* toggling directories in file dialog toggles more than one dir
* fix sort order in file dialog
* fix Save As not actually saving files
* update Cargo/Rust version and fix lint issues
* fix deleting EOF resulting in a crash
* change shortcut for backwards search to **b** as is documented